### PR TITLE
Update app for Nextcloud 31 compatibility

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-require_once './vendor-bin/cs-fixer/vendor/autoload.php';
+$autoload = __DIR__ . '/vendor-bin/cs-fixer/vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+}
 
 use Nextcloud\CodingStandard\Config;
 

--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@
 
 A plugin to take screen recordings and share them with your collegues.
 Skip the meetings!
+
+## Compatibility
+
+This version is tested with Nextcloud 31 and should work with newer releases as well.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 	<category>office</category>
 	<bugs>https://github.com/mijorus/rolls/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="29" max-version="29"/>
+               <nextcloud min-version="29" max-version="31"/>
 	</dependencies>
 	<screenshot>https://raw.githubusercontent.com/mijorus/rolls/master/docs/screenshot1.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/mijorus/rolls/master/docs/screenshot2.png</screenshot>

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"symfony/uid": "^6.4"
 	},
 	"require-dev": {
-		"nextcloud/ocp": "dev-stable29",
+               "nextcloud/ocp": "dev-stable31",
 		"roave/security-advisories": "dev-latest"
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -220,7 +220,7 @@
     "packages-dev": [
         {
             "name": "nextcloud/ocp",
-            "version": "dev-stable29",
+            "version": "dev-stable31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
@@ -242,7 +242,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-stable29": "29.0.0-dev"
+                    "dev-stable31": "31.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -258,7 +258,7 @@
             "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/stable29"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
             "time": "2024-06-08T00:35:50+00:00"
         },

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -17,9 +17,12 @@ class Application extends App implements IBootstrap {
 		parent::__construct(self::APP_ID);
 	}
 
-	public function register(IRegistrationContext $context): void {
-		require_once __DIR__ . '/../../vendor/autoload.php';
-	}
+       public function register(IRegistrationContext $context): void {
+               $autoload = __DIR__ . '/../../vendor/autoload.php';
+               if (file_exists($autoload)) {
+                       require_once $autoload;
+               }
+       }
 
 	public function boot(IBootContext $context): void {
 	}

--- a/lib/Controller/RollApiController.php
+++ b/lib/Controller/RollApiController.php
@@ -27,7 +27,6 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Util;
-use Symfony\Component\Uid\Uuid;
 use OCA\Rolls\Service\RollService;
 
 /**

--- a/lib/Db/RollsDb.php
+++ b/lib/Db/RollsDb.php
@@ -11,7 +11,6 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Share\IManager;
 use PDO;
-use Symfony\Component\Uid\Uuid;
 
 class RollsDb extends QBMapper {
 

--- a/lib/Service/RollService.php
+++ b/lib/Service/RollService.php
@@ -11,7 +11,7 @@ use OCA\Rolls\Utils\Funcs;
 use OCP\Files\IRootFolder;
 use OCP\IUserSession;
 use OCP\Share\IManager;
-use Symfony\Component\Uid\Uuid;
+use OCA\Rolls\Utils\UuidHelper;
 
 /**
  * @psalm-suppress UnusedClass
@@ -46,7 +46,7 @@ class RollService
 			$this->storage->newFolder($videoFolderName);
 		}
 
-		$uuid = Uuid::v4()->__toString();
+               $uuid = UuidHelper::v4();
 		$videoFolder = $this->storage->get($videoFolderName);
 
 		$foldernameBase = Funcs::joinPaths($videoFolder->getPath(),  'Roll_' . $uuid);

--- a/lib/Utils/UuidHelper.php
+++ b/lib/Utils/UuidHelper.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OCA\Rolls\Utils;
+
+class UuidHelper
+{
+    public static function v4(): string
+    {
+        $data = random_bytes(16);
+        $data[6] = chr((ord($data[6]) & 0x0f) | 0x40);
+        $data[8] = chr((ord($data[8]) & 0x3f) | 0x80);
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,10 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../../../tests/bootstrap.php';
-require_once __DIR__ . '/../vendor/autoload.php';
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+}
 
 \OC_App::loadApp(OCA\Rolls\AppInfo\Application::APP_ID);
 OC_Hook::clear();


### PR DESCRIPTION
## Summary
- expand supported Nextcloud versions
- require OCP stable31
- avoid missing vendor autoload at runtime
- add internal UUID generator

## Testing
- `phpunit -c tests/phpunit.xml --dont-report-useless-tests` *(fails: command not found)*
