### PR TITLE
Update app for Nextcloud 31 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@
 
 A plugin to take screen recordings and share them with your collegues.
 Skip the meetings!
+
+## Compatibility
+
+This version is tested with Nextcloud 31 and should work with newer releases as well.
+

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 	<category>office</category>
 	<bugs>https://github.com/mijorus/rolls/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="29" max-version="29"/>
+<nextcloud min-version="29" max-version="31"/>
 	</dependencies>
 	<screenshot>https://raw.githubusercontent.com/mijorus/rolls/master/docs/screenshot1.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/mijorus/rolls/master/docs/screenshot2.png</screenshot>

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,12 @@
 		"openapi": "generate-spec"
 	},
 	"require": {
-		"php": "^8.1",
-		"bamarni/composer-bin-plugin": "^1.8",
-		"symfony/uid": "^6.4"
-	},
-	"require-dev": {
-		"nextcloud/ocp": "dev-stable29",
-		"roave/security-advisories": "dev-latest"
+               "php": "^8.1",
+               "bamarni/composer-bin-plugin": "^1.8"
+       },
+       "require-dev": {
+               "nextcloud/ocp": "dev-stable31",
+               "roave/security-advisories": "dev-latest"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -62,165 +62,12 @@
                 "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.8.2"
             },
             "time": "2022-10-31T08:38:03+00:00"
-        },
-        {
-            "name": "symfony/polyfill-uuid",
-            "version": "v1.29.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "3abdd21b0ceaa3000ee950097bc3cf9efc137853"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/3abdd21b0ceaa3000ee950097bc3cf9efc137853",
-                "reference": "3abdd21b0ceaa3000ee950097bc3cf9efc137853",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-uuid": "*"
-            },
-            "suggest": {
-                "ext-uuid": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Uuid\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Grégoire Pineau",
-                    "email": "lyrixx@lyrixx.info"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for uuid functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "uuid"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.29.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-01-29T20:11:03+00:00"
-        },
-        {
-            "name": "symfony/uid",
-            "version": "v6.4.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/uid.git",
-                "reference": "35904eca37a84bb764c560cbfcac9f0ac2bcdbdf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/35904eca37a84bb764c560cbfcac9f0ac2bcdbdf",
-                "reference": "35904eca37a84bb764c560cbfcac9f0ac2bcdbdf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/polyfill-uuid": "^1.15"
-            },
-            "require-dev": {
-                "symfony/console": "^5.4|^6.0|^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Uid\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Grégoire Pineau",
-                    "email": "lyrixx@lyrixx.info"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an object-oriented API to generate and represent UIDs",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "UID",
-                "ulid",
-                "uuid"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/uid/tree/v6.4.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-05-31T14:49:08+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "nextcloud/ocp",
-            "version": "dev-stable29",
+            "version": "dev-stable31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
@@ -242,7 +89,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-stable29": "29.0.0-dev"
+                    "dev-stable31": "31.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -258,7 +105,7 @@
             "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/stable29"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
             "time": "2024-06-08T00:35:50+00:00"
         },

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -17,9 +17,12 @@ class Application extends App implements IBootstrap {
 		parent::__construct(self::APP_ID);
 	}
 
-	public function register(IRegistrationContext $context): void {
-		require_once __DIR__ . '/../../vendor/autoload.php';
-	}
+        public function register(IRegistrationContext $context): void {
+                $autoload = __DIR__ . '/../../vendor/autoload.php';
+                if (file_exists($autoload)) {
+                        require_once $autoload;
+                }
+        }
 
 	public function boot(IBootContext $context): void {
 	}

--- a/lib/Controller/RollApiController.php
+++ b/lib/Controller/RollApiController.php
@@ -27,7 +27,6 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Util;
-use Symfony\Component\Uid\Uuid;
 use OCA\Rolls\Service\RollService;
 
 /**

--- a/lib/Db/RollsDb.php
+++ b/lib/Db/RollsDb.php
@@ -11,7 +11,6 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Share\IManager;
 use PDO;
-use Symfony\Component\Uid\Uuid;
 
 class RollsDb extends QBMapper {
 

--- a/lib/Service/RollService.php
+++ b/lib/Service/RollService.php
@@ -11,7 +11,7 @@ use OCA\Rolls\Utils\Funcs;
 use OCP\Files\IRootFolder;
 use OCP\IUserSession;
 use OCP\Share\IManager;
-use Symfony\Component\Uid\Uuid;
+use OCA\Rolls\Utils\UuidHelper;
 
 /**
  * @psalm-suppress UnusedClass
@@ -46,7 +46,7 @@ class RollService
 			$this->storage->newFolder($videoFolderName);
 		}
 
-		$uuid = Uuid::v4()->__toString();
+                $uuid = UuidHelper::v4();
 		$videoFolder = $this->storage->get($videoFolderName);
 
 		$foldernameBase = Funcs::joinPaths($videoFolder->getPath(),  'Roll_' . $uuid);

--- a/lib/Utils/UuidHelper.php
+++ b/lib/Utils/UuidHelper.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OCA\Rolls\Utils;
+
+class UuidHelper {
+    public static function v4(): string {
+        $data = random_bytes(16);
+        $data[6] = chr((ord($data[6]) & 0x0f) | 0x40); // version 4
+        $data[8] = chr((ord($data[8]) & 0x3f) | 0x80); // variant RFC 4122
+        return vsprintf('%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x', array_values(unpack('C*', $data)));
+    }
+}


### PR DESCRIPTION
## Summary
- expand supported Nextcloud versions
- require OCP stable31 and drop symfony uid dependency
- add internal UUID helper and conditional autoloader

## Testing
- `phpunit -c tests/phpunit.xml --dont-report-useless-tests` *(fails: command not found)*